### PR TITLE
Serve index files if no file name is specified

### DIFF
--- a/Sources/DemoServer.swift
+++ b/Sources/DemoServer.swift
@@ -14,7 +14,8 @@ public func demoServer(publicDir: String) -> HttpServer {
     let server = HttpServer()
     
     server["/public/:path"] = HttpHandlers.shareFilesFromDirectory(publicDir)
-    
+    server["/public/"] = HttpHandlers.shareFilesFromDirectory(publicDir)    // needed to serve index file at root level
+
     server["/files/:path"] = HttpHandlers.directoryBrowser("/")
 
     server["/"] = { r in
@@ -109,7 +110,7 @@ public func demoServer(publicDir: String) -> HttpServer {
     server["/stream"] = { r in
         return HttpResponse.RAW(200, "OK", nil, { w in
             for i in 0...100 {
-                w.write([UInt8]("[chunk \(i)]".utf8));
+                w.write([UInt8]("[chunk \(i)]".utf8))
             }
         })
     }


### PR DESCRIPTION
This change allows use of addresses like
"http://localhost:9080/public/" or "http://localhost:9080/public/dir/"
and will serve "index.html" or "index.htm" if found in the folder.

To serve an index file at root level, you need to add a route like this:
`server["/public/"] = HttpHandlers.shareFilesFromDirectory(publicDir)`