### PR TITLE
Performancies improvement

### DIFF
--- a/Sources/HttpHandlers+Files.swift
+++ b/Sources/HttpHandlers+Files.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension HttpHandlers {
     
-    public class func shareFilesFromDirectory(directoryPath: String) -> (HttpRequest -> HttpResponse) {
+    public class func shareFilesFromDirectory(directoryPath: String, chunkSize: Int = 64) -> (HttpRequest -> HttpResponse) {
         return { r in
             guard let absolutePath = self.fileNameToShare(directoryPath, request: r) else {
                 return .NotFound
@@ -19,7 +19,7 @@ extension HttpHandlers {
                 return .NotFound
             }
             return .RAW(200, "OK", [:], { writer in
-                var buffer = [UInt8](count: 64, repeatedValue: 0)
+                var buffer = [UInt8](count: chunkSize, repeatedValue: 0)
                 while let count = try? file.read(&buffer) where count > 0 {
                     writer.write(buffer[0 ..< count])
                 }

--- a/Sources/HttpServerIO.swift
+++ b/Sources/HttpServerIO.swift
@@ -17,15 +17,15 @@ public class HttpServerIO {
     private var clientSockets: Set<Socket> = []
     private let clientSocketsLock = NSLock()
     
-    public func start(listenPort: in_port_t = 8080, forceIPv4: Bool = false) throws {
+    public func start(listenPort: in_port_t = 8080, forceIPv4: Bool = false, priority: Int = DISPATCH_QUEUE_PRIORITY_BACKGROUND) throws {
         stop()
         listenSocket = try Socket.tcpSocketForListen(listenPort, forceIPv4: forceIPv4)
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+        dispatch_async(dispatch_get_global_queue(priority, 0)) {
             while let socket = try? self.listenSocket.acceptClientSocket() {
                 self.lock(self.clientSocketsLock) {
                     self.clientSockets.insert(socket)
                 }
-                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), {
+                dispatch_async(dispatch_get_global_queue(priority, 0), {
                     self.handleConnection(socket)
                     self.lock(self.clientSocketsLock) {
                         self.clientSockets.remove(socket)


### PR DESCRIPTION
When running on OSX, the Swifter could be a little slow for some intensive functions, like serving big data. This could be easily fixed by changing the running priority and/or using bigger chunks in file serving.
This PR solve this issue by adding these two options, but keeps the default parameters for those who want to keep these.