### PR TITLE
Allow NSData to be written without memory copy

### DIFF
--- a/Sources/HttpResponse.swift
+++ b/Sources/HttpResponse.swift
@@ -20,6 +20,7 @@ public protocol HttpResponseBodyWriter {
     func write(file: File) throws
     func write(data: [UInt8]) throws
     func write(data: ArraySlice<UInt8>) throws
+    func write(data: NSData) throws
 }
 
 public enum HttpResponseBody {

--- a/Sources/HttpServerIO.swift
+++ b/Sources/HttpServerIO.swift
@@ -109,6 +109,10 @@ public class HttpServerIO {
         func write(data: ArraySlice<UInt8>) throws {
             try socket.writeUInt8(data)
         }
+
+        func write(data: NSData) throws {
+            try socket.writeData(data)
+        }
     }
     
     private func respond(socket: Socket, response: HttpResponse, keepAlive: Bool) throws -> Bool {

--- a/Swifter.podspec
+++ b/Swifter.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = "Swifter"
-  s.version               = "1.2.6"
+  s.version               = "3.0.0"
   s.summary               = "Tiny http server engine written in Swift programming language."
   s.homepage              = "https://github.com/glock45/swifter"
   s.license               = { :type => 'Copyright', :file => 'LICENSE' }

--- a/Swifter.podspec
+++ b/Swifter.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
-  s.source                = { :git => "https://github.com/glock45/swifter.git", :tag => "1.2.6" }
+  s.source                = { :git => "https://github.com/glock45/swifter.git", :tag => "3.0.0" }
   s.source_files          = 'Sources/*.{h,m,swift}'
 
 end

--- a/Swifter.podspec
+++ b/Swifter.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = "Swifter"
-  s.version               = "3.0.0"
+  s.version               = "1.2.6"
   s.summary               = "Tiny http server engine written in Swift programming language."
   s.homepage              = "https://github.com/glock45/swifter"
   s.license               = { :type => 'Copyright', :file => 'LICENSE' }
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
-  s.source                = { :git => "https://github.com/glock45/swifter.git", :tag => "3.0.0" }
+  s.source                = { :git => "https://github.com/glock45/swifter.git", :tag => "1.2.6" }
   s.source_files          = 'Sources/*.{h,m,swift}'
 
 end


### PR DESCRIPTION
`HttpResponseBodyWriter` can write `UInt8` arrays but not `NSData`, requiring a conversion between the two. This conversion involves an expensive memory copy from `NSData` to `UInt8` that can be avoided by adding a new method that allows `NSData` to be written to `HttpResponseBodyWriter`. 

I also updated the podspec file to version 3. Please let me know that should be in a separate pull request.