### PR TITLE
Thread safety fixes

### DIFF
--- a/XCode/Swifter.xcodeproj/project.pbxproj
+++ b/XCode/Swifter.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0858E7F41D68BB2600491CD1 /* IOSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858E7F31D68BB2600491CD1 /* IOSafetyTests.swift */; };
+		0858E7F51D68BB2600491CD1 /* IOSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858E7F31D68BB2600491CD1 /* IOSafetyTests.swift */; };
+		0858E7F71D68BC2600491CD1 /* PingServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858E7F61D68BC2600491CD1 /* PingServer.swift */; };
+		0858E7F81D68BC2600491CD1 /* PingServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858E7F61D68BC2600491CD1 /* PingServer.swift */; };
+		0858E7F91D68BC2600491CD1 /* PingServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858E7F61D68BC2600491CD1 /* PingServer.swift */; };
 		269B47881D3AAAE20042D137 /* HttpResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C76B6EF1D2C44F30030FC98 /* HttpResponse.swift */; };
 		269B47891D3AAAE20042D137 /* Scopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C76B6F41D2C44F30030FC98 /* Scopes.swift */; };
 		269B478A1D3AAAE20042D137 /* Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C76B6F31D2C44F30030FC98 /* Process.swift */; };
@@ -130,6 +135,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0858E7F31D68BB2600491CD1 /* IOSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IOSafetyTests.swift; sourceTree = "<group>"; };
+		0858E7F61D68BC2600491CD1 /* PingServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PingServer.swift; sourceTree = "<group>"; };
 		269B47A11D3AAAE20042D137 /* Swifter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swifter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		269B47A41D3AAC4F0042D137 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		269B47A51D3AAC4F0042D137 /* SwiftertvOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftertvOS.h; sourceTree = "<group>"; };
@@ -345,8 +352,10 @@
 			isa = PBXGroup;
 			children = (
 				7CCD876D1C660B250068099B /* SwifterTestsHttpParser.swift */,
+				0858E7F61D68BC2600491CD1 /* PingServer.swift */,
 				7CCD876E1C660B250068099B /* SwifterTestsStringExtensions.swift */,
 				7C4785E81C71D15600A9FE73 /* SwifterTestsWebSocketSession.swift */,
+				0858E7F31D68BB2600491CD1 /* IOSafetyTests.swift */,
 			);
 			path = SwifterTestsCommon;
 			sourceTree = "<group>";
@@ -716,6 +725,7 @@
 			files = (
 				7C73C6921C26179C00AEF6CA /* AppDelegate.swift in Sources */,
 				7CDAB8161BE2A1D400C8A977 /* ViewController.swift in Sources */,
+				0858E7F71D68BC2600491CD1 /* PingServer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -732,6 +742,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				7CCD87701C660B250068099B /* SwifterTestsHttpParser.swift in Sources */,
+				0858E7F81D68BC2600491CD1 /* PingServer.swift in Sources */,
+				0858E7F41D68BB2600491CD1 /* IOSafetyTests.swift in Sources */,
 				7C4785E91C71D15600A9FE73 /* SwifterTestsWebSocketSession.swift in Sources */,
 				7CCD87721C660B250068099B /* SwifterTestsStringExtensions.swift in Sources */,
 			);
@@ -742,6 +754,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				7CCD87841C660ED60068099B /* SwifterTestsHttpParser.swift in Sources */,
+				0858E7F91D68BC2600491CD1 /* PingServer.swift in Sources */,
+				0858E7F51D68BB2600491CD1 /* IOSafetyTests.swift in Sources */,
 				7C4785EA1C71D15600A9FE73 /* SwifterTestsWebSocketSession.swift in Sources */,
 				7CCD87851C660ED60068099B /* SwifterTestsStringExtensions.swift in Sources */,
 			);

--- a/XCode/SwifterTestsCommon/IOSafetyTests.swift
+++ b/XCode/SwifterTestsCommon/IOSafetyTests.swift
@@ -1,0 +1,40 @@
+//
+//  IOSafetyTests.swift
+//  Swifter
+//
+//  Created by Brian Gerstle on 8/20/16.
+//  Copyright © 2016 Damian Kołakowski. All rights reserved.
+//
+
+import XCTest
+import Swifter
+
+class IOSafetyTests: XCTestCase {
+    var server: HttpServer!
+
+    override func setUp() {
+        super.setUp()
+        server = HttpServer.pingServer()
+    }
+    
+    override func tearDown() {
+        if server.operating {
+            server.stop()
+        }
+        super.tearDown()
+    }
+
+    func testStopWithActiveConnections() {
+        (0...100).forEach { _ in
+            server = HttpServer.pingServer()
+            try! server.start()
+            XCTAssertFalse(NSURLSession.sharedSession().retryPing())
+            (0...100).forEach { _ in
+                dispatch_async(dispatch_get_global_queue(0, 0)) {
+                    NSURLSession.sharedSession().pingTask { _, _, _ in }.resume()
+                }
+            }
+            server.stop()
+        }
+    }
+}

--- a/XCode/SwifterTestsCommon/PingServer.swift
+++ b/XCode/SwifterTestsCommon/PingServer.swift
@@ -1,0 +1,64 @@
+//
+//  PingServer.swift
+//  Swifter
+//
+//  Created by Brian Gerstle on 8/20/16.
+//  Copyright © 2016 Damian Kołakowski. All rights reserved.
+//
+
+import Foundation
+import Swifter
+
+// Server
+extension HttpServer {
+    class func pingServer() -> HttpServer {
+        let server = HttpServer()
+        server.GET["/ping"] = { request in
+            return HttpResponse.OK(.Text("pong!"))
+        }
+        return server
+    }
+}
+
+let defaultLocalhost = NSURL(string:"http://localhost:8080")!
+
+// Client
+extension NSURLSession {
+    func pingTask(
+        hostURL: NSURL = defaultLocalhost,
+        completionHandler handler: (NSData?, NSURLResponse?, NSError?) -> Void
+    ) -> NSURLSessionDataTask {
+        return self.dataTaskWithURL(hostURL.URLByAppendingPathComponent("/ping"), completionHandler: handler)
+    }
+    
+    func retryPing(
+        hostURL: NSURL = defaultLocalhost,
+        timeout: Double = 2.0
+    ) -> Bool {
+        let semaphore = dispatch_semaphore_create(0)
+        self.signalIfPongReceived(semaphore, hostURL: hostURL)
+        let timeoutDate = NSDate().dateByAddingTimeInterval(timeout)
+        var timedOut = false
+        while dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW) != 0 {
+            if NSDate().laterDate(timeoutDate) != timeoutDate {
+                timedOut = true
+                break
+            }
+            NSRunLoop.currentRunLoop().runMode(
+                NSRunLoopCommonModes,
+                beforeDate: NSDate.distantFuture()
+            )
+        }
+        return timedOut
+    }
+    
+    func signalIfPongReceived(semaphore: dispatch_semaphore_t, hostURL: NSURL) {
+        pingTask(hostURL) { data, response, error in
+            if let httpResponse = response as? NSHTTPURLResponse where httpResponse.statusCode == 200 {
+                dispatch_semaphore_signal(semaphore)
+            } else {
+                self.signalIfPongReceived(semaphore, hostURL: hostURL)
+            }
+        }.resume()
+    }
+}


### PR DESCRIPTION
I was using this library to write a local "mock" API server, and starting/stopping it between test cases in `setUp` and `tearDown`.  I noticed I would occasionally get `EXC_BAD_ACCESS` when a client socket was being removed, and upon closer inspection, noticed the server's internal fields weren't being read & written from multiple threads.

I was able to reproduce the crash in the unit test I added, and was able to get it to pass consistently with the changes you see here.  In short, a serial queue was added to protect the`sockets` set and the `state` variable was protected by using `libatomic` primitives in the getter & setter.  