### PR TITLE
Bug fix with socket being shutdown multiple times

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -30,6 +30,8 @@ public enum SocketError: ErrorType {
 public class Socket: Hashable, Equatable {
         
     let socketFileDescriptor: Int32
+    private var shutdown = false
+
     
     public init(socketFileDescriptor: Int32) {
         self.socketFileDescriptor = socketFileDescriptor
@@ -42,10 +44,18 @@ public class Socket: Hashable, Equatable {
     public var hashValue: Int { return Int(self.socketFileDescriptor) }
     
     public func release() {
+        if shutdown {
+            return
+        }
+        shutdown = true
         Socket.release(self.socketFileDescriptor)
     }
     
     public func shutdwn() {
+        if shutdown {
+            return
+        }
+        shutdown = true
         Socket.shutdwn(self.socketFileDescriptor)
     }
     


### PR DESCRIPTION
I believe there's a bug in the socket class which causes a socket to be shutdown before it's meant to be.

How it happens: A Socket object gets created and shutdown by calling `release()`, the `deinit()` method has not yet been called. A new Socket object is created and happens to have the same file descriptor as the last Socket. When `deinit()` is called on the previous object it shuts down this file descriptor. This kills the newly created socket and causes a `WriteFailed("Broken pipe")` error.

I've fixed this by making sure `shutdown()` is only called once on the object.