### PR TITLE
Fixed mistake in pull request #187

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -30,7 +30,7 @@ public enum SocketError: ErrorType {
 public class Socket: Hashable, Equatable {
         
     let socketFileDescriptor: Int32
-    private var shutdown = false
+    private var released = false
 
     
     public init(socketFileDescriptor: Int32) {
@@ -44,18 +44,17 @@ public class Socket: Hashable, Equatable {
     public var hashValue: Int { return Int(self.socketFileDescriptor) }
     
     public func release() {
-        if shutdown {
+        if released {
             return
         }
-        shutdown = true
+        released = true
         Socket.release(self.socketFileDescriptor)
     }
     
     public func shutdwn() {
-        if shutdown {
+        if released {
             return
         }
-        shutdown = true
         Socket.shutdwn(self.socketFileDescriptor)
     }
     


### PR DESCRIPTION
I submitted a pull request ([#187](https://github.com/httpswift/swifter/pull/187)) last week that would fix an issue with sockets getting mistakenly closed. There is a bug in this fix where sockets that have been shutdown can't ever be closed. This is my mistake and has been amended in the commit below. 

I also had a question regarding the `deinit` call on line 40 of Socket.swift. Should this be calling `release` or `shutdwn`? If `shutdwn` is called, then the socket isn't actually closed on `deinit`, is this expected behaviour?

Thanks for the help.
