### PR TITLE
Fixed HttpServerIODelegate to public and class

### DIFF
--- a/Sources/HttpServerIO.swift
+++ b/Sources/HttpServerIO.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Dispatch
 
-protocol HttpServerIODelegate {
+public protocol HttpServerIODelegate: class {
     func socketConnectionReceived(_ socket: Socket)
 }
 


### PR DESCRIPTION
It fails on Xcode 8.2.1 without it.