### PR TITLE
Handling Chinese filename

### DIFF
--- a/Sources/HttpRequest.swift
+++ b/Sources/HttpRequest.swift
@@ -124,16 +124,16 @@ public class HttpRequest {
     }
     
     private func nextMultiPartLine(_ generator: inout IndexingIterator<[UInt8]>) -> String? {
-        var result = String()
+        var temp = [UInt8]()
         while let value = generator.next() {
             if value > HttpRequest.CR {
-                result.append(Character(UnicodeScalar(value)))
+                temp.append(value)
             }
             if value == HttpRequest.NL {
                 break
             }
         }
-        return result
+        return String(bytes: temp, encoding: String.Encoding.utf8)
     }
     
     static let CR = UInt8(13)


### PR DESCRIPTION
Uploading file with Chinese name would return a gabled file name

File name: 傳說對決.png
expect: 傳說對決.png
What I got: [Garbled string].png
