### PR TITLE
Added an option to set the listening address

### DIFF
--- a/Sources/Socket+Server.swift
+++ b/Sources/Socket+Server.swift
@@ -8,19 +8,23 @@
 import Foundation
 
 extension Socket {
-    
-    public class func tcpSocketForListen(_ port: in_port_t, _ forceIPv4: Bool = false, _ maxPendingConnection: Int32 = SOMAXCONN) throws -> Socket {
-        
+
+    /// - Parameters:
+    ///   - listenAddress: String representation of the address the socket should accept
+    ///       connections from. It should be in IPv4 format if forceIPv4 == true,
+    ///       otherwise - in IPv6.
+    public class func tcpSocketForListen(_ port: in_port_t, _ forceIPv4: Bool = false, _ maxPendingConnection: Int32 = SOMAXCONN, _ listenAddress: String? = nil) throws -> Socket {
+
         #if os(Linux)
             let socketFileDescriptor = socket(forceIPv4 ? AF_INET : AF_INET6, Int32(SOCK_STREAM.rawValue), 0)
         #else
             let socketFileDescriptor = socket(forceIPv4 ? AF_INET : AF_INET6, SOCK_STREAM, 0)
         #endif
-        
+
         if socketFileDescriptor == -1 {
             throw SocketError.socketCreationFailed(Errno.description())
         }
-        
+
         var value: Int32 = 1
         if setsockopt(socketFileDescriptor, SOL_SOCKET, SO_REUSEADDR, &value, socklen_t(MemoryLayout<Int32>.size)) == -1 {
             let details = Errno.description()
@@ -28,7 +32,6 @@ extension Socket {
             throw SocketError.socketSettingReUseAddrFailed(details)
         }
         Socket.setNoSigPipe(socketFileDescriptor)
-        
 
         var bindResult: Int32 = -1
         if forceIPv4 {
@@ -46,6 +49,13 @@ extension Socket {
                 sin_addr: in_addr(s_addr: in_addr_t(0)),
                 sin_zero:(0, 0, 0, 0, 0, 0, 0, 0))
             #endif
+            if let address = listenAddress {
+              if address.withCString({ cstring in inet_pton(AF_INET, cstring, &addr.sin_addr) }) == 1 {
+                // print("\(address) is converted to \(addr.sin_addr).")
+              } else {
+                // print("\(address) is not converted.")
+              }
+            }
             bindResult = withUnsafePointer(to: &addr) {
                 bind(socketFileDescriptor, UnsafePointer<sockaddr>(OpaquePointer($0)), socklen_t(MemoryLayout<sockaddr_in>.size))
             }
@@ -66,17 +76,24 @@ extension Socket {
                 sin6_addr: in6addr_any,
                 sin6_scope_id: 0)
             #endif
+            if let address = listenAddress {
+              if address.withCString({ cstring in inet_pton(AF_INET6, cstring, &addr.sin6_addr) }) == 1 {
+                //print("\(address) is converted to \(addr.sin6_addr).")
+              } else {
+                //print("\(address) is not converted.")
+              }
+            }
             bindResult = withUnsafePointer(to: &addr) {
                 bind(socketFileDescriptor, UnsafePointer<sockaddr>(OpaquePointer($0)), socklen_t(MemoryLayout<sockaddr_in6>.size))
             }
         }
-        
+
         if bindResult == -1 {
             let details = Errno.description()
             Socket.close(socketFileDescriptor)
             throw SocketError.bindFailed(details)
         }
-        
+
         if listen(socketFileDescriptor, maxPendingConnection) == -1 {
             let details = Errno.description()
             Socket.close(socketFileDescriptor)


### PR DESCRIPTION
I'm integrating the server into my test app (i.e. the one containing `XCTestCase`s). The issue with this setup is that when a test tries to start the server on the emulator a macOS dialog asking for network permissions appears. It blocks the testing process, especially on a CI server.

The reason for that dialog to appear is that the server listens to requests from all IPs (that is "0.0.0.0" or "0.0.0.0.0.0.0.0"). When the server listens to localhost ("127.0.0.1" or "0.0.0.0.0.0.0.1") the additional permissions are not required (no dialog appearing).

Thus, this PR proposes changes to allow setting the listening address for the server.