### PR TITLE
Fix crash in iOS Sample app when `StopServer` button is pressed

### DIFF
--- a/XCode/SwifterSampleiOS/ViewController.swift
+++ b/XCode/SwifterSampleiOS/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func likedThis(sender: UIButton) {
+    @IBAction func likedThis(_ sender: UIButton) {
         self.server?.stop()
         self.server = nil
     }


### PR DESCRIPTION
`@IBAction func likedThis(sender: UIButton)` bridges to selector `likedThisWithSender` but button tries to invoke `likedThis` selector. Adding `_` causes method to have correct selector. I assume this bug was introduced during migration to Swift 3.0.