### PR TITLE
Hacking/unix socket

### DIFF
--- a/Sources/HttpServerIO.swift
+++ b/Sources/HttpServerIO.swift
@@ -66,8 +66,16 @@ public class HttpServerIO {
         return Int(try socket.port())
     }
 
+    public func localPath() throws -> String {
+        return try socket.localPath()
+    }
+
     public func isIPv4() throws -> Bool {
         return try socket.isIPv4()
+    }
+
+    public func isLocal() throws -> Bool {
+        return try socket.isLocal()
     }
 
     deinit {
@@ -85,15 +93,11 @@ public class HttpServerIO {
     }
 
     @available(macOS 10.10, *)
-    public func startLocal(_ socketPath: String? = nil, priority: DispatchQoS.QoSClass = DispatchQoS.QoSClass.background) throws {
-        guard let path = socketPath ?? self.listenLocalPath else {
-            // Caller did not specify local path property or parameter
-            throw SocketError.noLocalPath
-        }
+    public func startLocal(_ socketPath: String, priority: DispatchQoS.QoSClass = DispatchQoS.QoSClass.background) throws {
         guard !self.operating else { return }
         stop()
         self.state = .starting
-        self.socket = try Socket.localSocketForListen(path, SOMAXCONN)
+        self.socket = try Socket.localSocketForListen(socketPath, SOMAXCONN)
         startListener(priority)
     }
 

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum SocketError: Error {
     case socketCreationFailed(String)
     case socketSettingReUseAddrFailed(String)
+    case localPathTooLong(String)
     case bindFailed(String)
     case listenFailed(String)
     case writeFailed(String)

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum SocketError: Error {
     case socketCreationFailed(String)
     case socketSettingReUseAddrFailed(String)
+    case noLocalPath
     case localPathTooLong(String)
     case bindFailed(String)
     case listenFailed(String)

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -11,7 +11,6 @@ import Foundation
 public enum SocketError: Error {
     case socketCreationFailed(String)
     case socketSettingReUseAddrFailed(String)
-    case noLocalPath
     case localPathTooLong(String)
     case bindFailed(String)
     case listenFailed(String)
@@ -22,6 +21,8 @@ public enum SocketError: Error {
     case acceptFailed(String)
     case recvFailed(String)
     case getSockNameFailed(String)
+    case notNetworkSocket
+    case notLocalSocket
 }
 
 open class Socket: Hashable, Equatable {
@@ -47,9 +48,37 @@ open class Socket: Hashable, Equatable {
         shutdown = true
         Socket.close(self.socketFileDescriptor)
     }
-    
-    public func port() throws -> in_port_t {
+
+    private func getSockaddrIn() throws -> sockaddr_in {
         var addr = sockaddr_in()
+        try withUnsafePointer(to: &addr) { pointer in
+            var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+            if getsockname(socketFileDescriptor, UnsafeMutablePointer(OpaquePointer(pointer)), &len) != 0 {
+                throw SocketError.getSockNameFailed(Errno.description())
+            }
+        }
+        guard (Int32(addr.sin_family) == AF_INET) || (Int32(addr.sin_family) == AF_INET6) else {
+            throw SocketError.notNetworkSocket
+        }
+        return addr
+    }
+    
+    private func getSockaddrUn() throws -> sockaddr_un {
+        var addr = sockaddr_un()
+        try withUnsafePointer(to: &addr) { pointer in
+            var len = socklen_t(MemoryLayout<sockaddr_un>.size)
+            if getsockname(socketFileDescriptor, UnsafeMutablePointer(OpaquePointer(pointer)), &len) != 0 {
+                throw SocketError.getSockNameFailed(Errno.description())
+            }
+        }
+        guard Int32(addr.sun_family) == AF_LOCAL else {
+            throw SocketError.notLocalSocket
+        }
+        return addr
+    }
+
+    public func port() throws -> in_port_t {
+        var addr = try getSockaddrIn()
         return try withUnsafePointer(to: &addr) { pointer in
             var len = socklen_t(MemoryLayout<sockaddr_in>.size)
             if getsockname(socketFileDescriptor, UnsafeMutablePointer(OpaquePointer(pointer)), &len) != 0 {
@@ -64,14 +93,42 @@ open class Socket: Hashable, Equatable {
     }
     
     public func isIPv4() throws -> Bool {
-        var addr = sockaddr_in()
+        var addr: sockaddr_in
+        do {
+            addr = try getSockaddrIn()
+        } catch SocketError.notNetworkSocket {
+            return false
+        } catch {
+            throw error
+        }
+        return Int32(addr.sin_family) == AF_INET
+    }
+
+    public func localPath() throws -> String {
+        var addr = try getSockaddrUn()
         return try withUnsafePointer(to: &addr) { pointer in
-            var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+            var len = socklen_t(MemoryLayout<sockaddr_un>.size)
             if getsockname(socketFileDescriptor, UnsafeMutablePointer(OpaquePointer(pointer)), &len) != 0 {
                 throw SocketError.getSockNameFailed(Errno.description())
             }
-            return Int32(addr.sin_family) == AF_INET
+            return withUnsafePointer(to: &addr.sun_path) { path in
+                let pathLen = MemoryLayout.size(ofValue: addr.sun_path)
+                return path.withMemoryRebound(to: UInt8.self, capacity: pathLen) { bytes in
+                    return String(cString: bytes)
+                }
+            }
         }
+    }
+
+    public func isLocal() throws -> Bool {
+        do {
+            let _ = try getSockaddrUn()
+        } catch SocketError.notLocalSocket {
+            return false
+        } catch {
+            throw error
+        }
+        return true
     }
     
     public func writeUTF8(_ string: String) throws {

--- a/XCode/SwifterSampleOSX/main.swift
+++ b/XCode/SwifterSampleOSX/main.swift
@@ -9,17 +9,29 @@ import Swifter
 
 do {
     let server = demoServer(try String.File.currentWorkingDirectory())
+    let localserver = demoServer(try String.File.currentWorkingDirectory())
     server["/testAfterBaseRoute"] = { request in
         return .ok(.html("ok !"))
     }
-    
+    localserver["/testAfterBaseRoute"] = { request in
+        return .ok(.html("ok !"))
+    }
+
+    let localpath = NSHomeDirectory() + "/.sampleSocket"
+
     if #available(OSXApplicationExtension 10.10, *) {
         try server.start(9080, forceIPv4: true)
+        // The OS won't automatically delete this when the program ends, and it can't be reused
+        if FileManager.default.fileExists(atPath: localpath) {
+            try FileManager.default.removeItem(atPath: localpath)
+        }
+        try localserver.startLocal(localpath)
     } else {
         // Fallback on earlier versions
     }
-    
+
     print("Server has started ( port = \(try server.port()) ). Try to connect now...")
+    print("Local server has started ( path = \(try localserver.localPath()) ). Try connecting...")
     
     RunLoop.main.run()
     


### PR DESCRIPTION
Will need more tests but appears to work in the ones I have already. Look at Sources/DemoServer.swift and SwifterSampleOSX/main.swift for a usage example.

Note that neither the OS nor the program automatically delete the local socket created (in the sample code, at ~/.sampleSocket) when the program exits. This is a weird quirk of Unix sockets; you just have to delete them manually (or put cleanup code in your software to delete them, though that won't work for abnormal termination). You'd think they'd be temp files bound to the lifetime of their process, but noooooo that would be logical.

Also note that the complete path to the socket needs to be 104 bytes or less, including null terminator. This is an OS restriction (it's only slightly longer on Linux) and is enforced by the code I added. Thus the short path (~/.sampleSocket) rather than using the current directory or something; XCode's build output paths are too long.

You can test the code by running the SwifterSampleOSX in Xcode, verifying that it launches successfully, and then executing the following command in a terminal:
`printf 'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n' | nc -U ~/.sampleSocket`