### PR TITLE
Allow low-level access to socket

### DIFF
--- a/Sources/WebSockets.swift
+++ b/Sources/WebSockets.swift
@@ -142,7 +142,7 @@ public class WebSocketSession: Hashable, Equatable  {
         public var payload = [UInt8]()
     }
 
-    let socket: Socket
+    public let socket: Socket
     
     public init(_ socket: Socket) {
         self.socket = socket


### PR DESCRIPTION
Allowing application access to the underlying socket is a simple way to support the occasional need for something very specific, such as to block a certain peer or check the underlying state of the socket.

(In my case, the specific need is to see errors from write operations, but that is a more extensive change to the API. This small change should allow closed sockets to be detected prior to writing, at least.)