### PR TITLE
remove split string extension from being public

### DIFF
--- a/Sources/HttpRouter.swift
+++ b/Sources/HttpRouter.swift
@@ -134,7 +134,7 @@ open class HttpRouter {
 
 extension String {
     
-    public func split(_ separator: Character) -> [String] {
+    func split(_ separator: Character) -> [String] {
         return self.split { $0 == separator }.map(String.init)
     }
     


### PR DESCRIPTION
since this extension is only used internally, there is no need to make
this public. this avoids having this extension clash with other user
defined split functions when using this library