### PR TITLE
Turn off `Always Embed Swift Standard Libraries` for `SwifterMac` target.

### DIFF
--- a/XCode/Swifter.xcodeproj/project.pbxproj
+++ b/XCode/Swifter.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 		7AE894011C0512C400A29F63 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1.3.3;
@@ -966,6 +967,7 @@
 		7AE894021C0512C400A29F63 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;


### PR DESCRIPTION
When the `SwifterMac` target is built, the resulting `Swifter.framework` contains Swift's standard library `dylib`s.